### PR TITLE
Fix entry setup for new HA

### DIFF
--- a/custom_components/ha_endolla/__init__.py
+++ b/custom_components/ha_endolla/__init__.py
@@ -6,6 +6,7 @@ import async_timeout
 from datetime import timedelta
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.const import Platform
 from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
     UpdateFailed,
@@ -15,6 +16,7 @@ from .const import DOMAIN, CONF_STATION_ID, ENDOLLA_URL
 _LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(minutes=5)
+PLATFORMS = [Platform.SENSOR]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up the Endolla integration from a config entry."""
@@ -29,16 +31,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # First fetch immediately
     await coordinator.async_config_entry_first_refresh()
 
-    # Forward to sensor platform
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(entry, "sensor")
-    )
+    # Forward entry setup to sensor platform(s)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_forward_entry_unload(entry, "sensor")
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)
     return unload_ok


### PR DESCRIPTION
## Summary
- handle updated Home Assistant API for entry setups/unloads

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e8808a5848332bf8eaa42e8e45314